### PR TITLE
Set up the molecule cluster UT env.

### DIFF
--- a/molecule/cluster/converge.yml
+++ b/molecule/cluster/converge.yml
@@ -16,9 +16,5 @@
 
     - name: Create the Operator Deployment
       k8s:
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) }}"
         namespace: '{{ namespace }}'
-        definition: "{{ lookup('template', '/'.join([template_dir, 'operator.yaml.j2'])) }}"
-        wait: yes
-      vars:
-        image: '{{ operator_image }}'
-        pull_policy: '{{ operator_pull_policy }}'

--- a/molecule/cluster/destroy.yml
+++ b/molecule/cluster/destroy.yml
@@ -3,32 +3,41 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  no_log: "{{ molecule_no_log }}"
+  #no_log: "{{ molecule_no_log }}"
   collections:
     - community.kubernetes
 
   tasks:
-    - name: Delete namespace
+    - name: Delete Epg Custom Resource Definition
       k8s:
-        api_version: v1
-        kind: Namespace
-        name: '{{ namespace }}'
+        definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/aci.aw_epgs_crd.yaml'])) }}"
         state: absent
         wait: yes
 
-    - name: Delete RBAC resources
+    - name: Delete Contract Custom Resource Definition
+      k8s:
+        definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/aci.aw_contracts_crd.yaml'])) }}"
+        state: absent
+        wait: yes
+
+    - name: Delete RBAC resources and the operator itself
       k8s:
         definition: "{{ lookup('template', '/'.join([deploy_dir, item])) }}"
         namespace: '{{ namespace }}'
         state: absent
         wait: yes
       with_items:
+        - operator.yaml
         - role.yaml
         - role_binding.yaml
         - service_account.yaml
 
-    - name: Delete Custom Resource Definition
+    - name: Do Not Delete namespace
       k8s:
-        definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/aci.aw_epgs_crd.yaml'])) }}"
-        state: absent
+        api_version: v1
+        kind: Namespace
+        name: '{{ namespace }}'
+        # We have to use aci-containers-system namespace for the UTs
+        # so don't delete it as other resources also depend on it.
+        state: present
         wait: yes

--- a/molecule/cluster/molecule.yml
+++ b/molecule/cluster/molecule.yml
@@ -18,13 +18,14 @@ provisioner:
   inventory:
     group_vars:
       all:
-        namespace: ${TEST_OPERATOR_NAMESPACE:-osdk-test}
+        namespace: ${TEST_OPERATOR_NAMESPACE:-aci-containers-system}
     host_vars:
       localhost:
         ansible_python_interpreter: '{{ ansible_playbook_python }}'
         deploy_dir: ${MOLECULE_PROJECT_DIRECTORY}/deploy
         template_dir: ${MOLECULE_PROJECT_DIRECTORY}/molecule/templates
-        operator_image: ${OPERATOR_IMAGE:-""}
+        # TBD: use the official repo
+        operator_image: ${OPERATOR_IMAGE:-"kentwu111/aci-ansible-operator:v1"}
         operator_pull_policy: ${OPERATOR_PULL_POLICY:-"Always"}
   env:
     K8S_AUTH_KUBECONFIG: ${KUBECONFIG:-"~/.kube/config"}

--- a/molecule/cluster/prepare.yml
+++ b/molecule/cluster/prepare.yml
@@ -15,6 +15,10 @@
       k8s:
         definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/aci.aw_epgs_crd.yaml'])) }}"
 
+    - name: Create Contract Custom Resource Definition
+      k8s:
+        definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/aci.aw_contracts_crd.yaml'])) }}"
+
     - name: Create namespace
       k8s:
         api_version: v1

--- a/molecule/cluster/verify.yml
+++ b/molecule/cluster/verify.yml
@@ -8,14 +8,27 @@
     - community.kubernetes
 
   vars:
-    custom_resource: "{{ lookup('template', '/'.join([deploy_dir, 'crds/aci.aw_v1_epg_cr.yaml'])) | from_yaml }}"
+    epg_custom_resource: "{{ lookup('template', '/'.join([deploy_dir, 'crds/aci.aw_v1_epg_cr.yaml'])) | from_yaml }}"
+    contract_custom_resource: "{{ lookup('template', '/'.join([deploy_dir, 'crds/aci.aw_v1_contract_cr.yaml'])) | from_yaml }}"
 
   tasks:
     - name: Create the aci.aw/v1.Epg and wait for reconciliation to complete
       k8s:
         state: present
         namespace: '{{ namespace }}'
-        definition: '{{ custom_resource }}'
+        definition: '{{ epg_custom_resource }}'
+        wait: yes
+        wait_timeout: 300
+        wait_condition:
+          type: Running
+          reason: Successful
+          status: "True"
+
+    - name: Create the aci.aw/v1.Contract and wait for reconciliation to complete
+      k8s:
+        state: present
+        namespace: '{{ namespace }}'
+        definition: '{{ contract_custom_resource }}'
         wait: yes
         wait_timeout: 300
         wait_condition:

--- a/molecule/templates/operator.yaml.j2
+++ b/molecule/templates/operator.yaml.j2
@@ -13,6 +13,17 @@ spec:
       labels:
         name: aci-ansible-operator
     spec:
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       serviceAccountName: aci-ansible-operator
       containers:
         - name: aci-ansible-operator
@@ -22,6 +33,10 @@ spec:
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner
+          - mountPath: /usr/local/etc/aci-cert/
+            name: aci-user-cert-volume
+          - name: aci-containers-config-volume
+            mountPath: /opt/ansible/aci-containers-config/
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -45,3 +60,10 @@ spec:
       volumes:
         - name: runner
           emptyDir: {}
+        - name: aci-containers-config-volume
+          configMap:
+            name: aci-containers-config
+        - name: aci-user-cert-volume
+          secret:
+            defaultMode: 420
+            secretName: aci-user-cert


### PR DESCRIPTION
1. For the operator deployment,
a. Use the operator.yml file directly to test the real world
deployment.
b. I've also enhanced the template operator.yaml.j2 file so
we can still choose to use that if that's desired somehow.

2. Create the Contract CRD in the prepare phase. Also add
the Contract testing in the verify phase.

4. For the destroy task,
a. The destroy sequence should do both CRDs first so that
operator can clean up the APIC resources accordingly.
b. Also add the operator itself to the destroy list.
c. The namespace deletion should be the last one to go
otherwise it will automatically delete all the resources
under this namespace. Also we don't really need to delete
the namespace here cause we have to use aci-containers-system
namespace for this testing.

5. Populate the namespace and operator_image parameters in the
molecule.yml file.