### PR TITLE
Fix some bugs

### DIFF
--- a/molecule/cluster/verify.yml
+++ b/molecule/cluster/verify.yml
@@ -18,9 +18,8 @@
         namespace: '{{ epg_custom_resource.metadata.namespace }}'
       spec:
         epg_contract_masters:
-          - epg9
-          - epg10
-          - aci-containers-systems
+          - aci-containers-istio
+          - aci-containers-system
         provided_contracts: []
         consumed_contracts:
           - c3

--- a/playbooks/contract-playbook.yaml
+++ b/playbooks/contract-playbook.yaml
@@ -5,7 +5,7 @@
   vars:
     jsonVar: "{{ lookup('file', '/opt/ansible/aci-containers-config/controller-config') | from_json }}"
     user: "{{ jsonVar['apic-username'] }}"
-    tenant: "{{ jsonVar['apic-username'] }}"
+    tenant: "{{ jsonVar['aci-policy-tenant'] }}"
     certKey: "{{ jsonVar['apic-private-key-path'] }}"
     certName: '{{ user }}.crt'
     apicHosts: "{{ jsonVar['apic-hosts'] }}"

--- a/playbooks/epg-playbook.yaml
+++ b/playbooks/epg-playbook.yaml
@@ -191,7 +191,6 @@
     when: (desiredState == 'present') and (query_result.imdata is defined) and (epgPath in item.fvRsSecInherited.attributes.dn) and (item.fvRsSecInherited.attributes.tDn.split("/")[-1][4:] not in masterEpgs)
   - name: Attach Master EPGs
     when: (desiredState == 'present')
-    ignore_errors: yes
     cisco.aci.aci_epg_to_contract_master:
       host: '{{ apicHost }}'
       cert_key: '{{ certKey }}'


### PR DESCRIPTION
1. Use the right config parameter for tenant in contract playbook.
2. In APIC 5.0, configuring a master EPG will fail if such master
EPG doesn't exist. We should just let the ansible operator fail
in that case otherwise user will not be aware of that at all. Also
adjusted the test case for that.