### PR TITLE
Add the annotation support to both EPG and Contract CRD

### DIFF
--- a/playbooks/contract-playbook.yaml
+++ b/playbooks/contract-playbook.yaml
@@ -13,23 +13,24 @@
     contractName: '{{ meta.name }}'
     allowList: '{{ allow_list }}'
     desiredState: '{{ state }}'
+    annotation: 'orchestrator:aci-ansible-operator'
   tasks:
   - name: Create/Delete a contract
-    aci_contract:
+    cisco.aci.aci_contract:
       host: '{{ apicHost }}'
       cert_key: '{{ certKey }}'
       certificate_name: '{{ certName }}'
       username: '{{ user }}'
       tenant: '{{ tenant }}'
       contract: '{{ contractName }}'
-      # TBD: annotation
+      annotation: '{{ annotation }}'
       use_ssl: yes
       validate_certs: no
       use_proxy: no
       state: '{{ desiredState }}'
   - name: Create a subject
     when: desiredState == 'present'
-    aci_contract_subject:
+    cisco.aci.aci_contract_subject:
       host: '{{ apicHost }}'
       cert_key: '{{ certKey }}'
       certificate_name: '{{ certName }}'
@@ -37,25 +38,27 @@
       tenant: '{{ tenant }}'
       contract: '{{ contractName }}'
       subject: 'default'
+      annotation: '{{ annotation }}'
       use_ssl: yes
       validate_certs: no
       use_proxy: no
       state: present
   - name: Create/Delete a filter
-    aci_filter:
+    cisco.aci.aci_filter:
       host: '{{ apicHost }}'
       cert_key: '{{ certKey }}'
       certificate_name: '{{ certName }}'
       username: '{{ user }}'
       tenant: '{{ tenant }}'
       filter: '{{ contractName }}-default'
+      annotation: '{{ annotation }}'
       use_ssl: yes
       validate_certs: no
       use_proxy: no
       state: '{{ desiredState }}'
   - name: Query entries
     when: desiredState == 'present'
-    aci_filter_entry:
+    cisco.aci.aci_filter_entry:
       host: '{{ apicHost }}'
       cert_key: '{{ certKey }}'
       certificate_name: '{{ certName }}'
@@ -67,23 +70,44 @@
       use_proxy: no
       state: query
     register: query_result
+  - name: Query each entry to get its annotation
+    cisco.aci.aci_filter_entry:
+      host: '{{ apicHost }}'
+      cert_key: '{{ certKey }}'
+      certificate_name: '{{ certName }}'
+      username: '{{ user }}'
+      tenant: '{{ tenant }}'
+      filter: '{{ contractName }}-default'
+      entry: '{{ item.vzEntry.attributes.name }}'
+      use_ssl: yes
+      validate_certs: no
+      use_proxy: no
+      state: query
+    with_items: "{{ query_result.current[0].vzFilter.children }}"
+    when: (desiredState == 'present') and (query_result.current[0].vzFilter.children is defined)
+    register: entry_query_result
   - name: Set the default entry list
     when: desiredState == 'present'
     set_fact:
       entryList: []
   - name: Set the entry list
     set_fact:
-      entryList: "{{ entryList|default([]) + ['-'.join((item.protocol, item.ports.start|string(), item.ports.end|string()))] }}"
+      entryList: "{{ entryList + ['-'.join((item.protocol, item.ports.start|string(), item.ports.end|string()))] }}"
     with_items: "{{ allowList }}"
     when: (desiredState == 'present') and (item.ports is defined)
   - name: Set the entry list for ICMP
     set_fact:
-      entryList: "{{ entryList|default([]) + ['-'.join((item.protocol, 'unspecified', 'unspecified'))] }}"
+      entryList: "{{ entryList + ['-'.join((item.protocol, 'unspecified', 'unspecified'))] }}"
     with_items: "{{ allowList }}"
     when: (desiredState == 'present') and (item.ports is not defined)
+  - name: Add the entries not owned by us to the entry list
+    set_fact:
+      entryList: "{{ entryList + [item.item.vzEntry.attributes.name] }}"
+    with_items: "{{ entry_query_result.results }}"
+    when: (desiredState == 'present') and (entry_query_result.results is defined) and (item.item.vzEntry.attributes.annotation != annotation)
   - name: Delete extra entries
     ignore_errors: yes
-    aci_filter_entry:
+    cisco.aci.aci_filter_entry:
       host: '{{ apicHost }}'
       cert_key: '{{ certKey }}'
       certificate_name: '{{ certName }}'
@@ -98,7 +122,7 @@
     with_items: "{{ query_result.current[0].vzFilter.children }}"
     when: (desiredState == 'present') and (query_result.current[0].vzFilter.children is defined) and (item.vzEntry.attributes.name not in entryList)
   - name: Create entries
-    aci_filter_entry:
+    cisco.aci.aci_filter_entry:
       host: '{{ apicHost }}'
       cert_key: '{{ certKey }}'
       certificate_name: '{{ certName }}'
@@ -106,6 +130,7 @@
       tenant: '{{ tenant }}'
       filter: '{{ contractName }}-default'
       entry: "{{ '-'.join((item.protocol, item.ports.start|string(), item.ports.end|string())) }}"
+      annotation: '{{ annotation }}'
       ether_type: 'ip'
       ip_protocol: '{{ item.protocol }}'
       dst_port_start: '{{ item.ports.start }}'
@@ -117,7 +142,7 @@
     with_items: "{{ allowList }}"
     when: (desiredState == 'present') and (item.ports is defined)
   - name: Create entries for ICMP which doesn't have ports defined
-    aci_filter_entry:
+    cisco.aci.aci_filter_entry:
       host: '{{ apicHost }}'
       cert_key: '{{ certKey }}'
       certificate_name: '{{ certName }}'
@@ -125,6 +150,7 @@
       tenant: '{{ tenant }}'
       filter: '{{ contractName }}-default'
       entry: "{{ '-'.join((item.protocol, 'unspecified', 'unspecified')) }}"
+      annotation: '{{ annotation }}'
       ether_type: 'ip'
       ip_protocol: '{{ item.protocol }}'
       use_ssl: yes
@@ -135,7 +161,7 @@
     when: (desiredState == 'present') and (item.ports is not defined)
   - name: Bind the subject to the filter
     when: desiredState == 'present'
-    aci_contract_subject_to_filter:
+    cisco.aci.aci_contract_subject_to_filter:
       host: '{{ apicHost }}'
       cert_key: '{{ certKey }}'
       certificate_name: '{{ certName }}'
@@ -144,6 +170,7 @@
       contract: '{{ contractName }}'
       subject: 'default'
       filter: '{{ contractName }}-default'
+      annotation: '{{ annotation }}'
       use_ssl: yes
       validate_certs: no
       use_proxy: no

--- a/playbooks/epg-playbook.yaml
+++ b/playbooks/epg-playbook.yaml
@@ -20,9 +20,11 @@
     providedContracts: '{{ provided_contracts }}'
     consumedContracts: '{{ consumed_contracts }}'
     desiredState: '{{ state }}'
+    annotation: 'orchestrator:aci-ansible-operator'
+    epgPath: 'uni/tn-{{ tenant }}/ap-{{ ap }}/epg-{{ epgName }}'
   tasks:
-  - name: create EPG
-    aci_epg:
+  - name: Create/Delete the EPG
+    cisco.aci.aci_epg:
       host: '{{ apicHost }}'
       cert_key: '{{ certKey }}'
       certificate_name: '{{ certName }}'
@@ -31,7 +33,7 @@
       ap: '{{ ap }}'
       epg: '{{ epgName }}'
       bd: '{{ bd }}'
-      # TBD: annotation?
+      annotation: '{{ annotation }}'
       use_ssl: yes
       validate_certs: no
       use_proxy: no
@@ -39,7 +41,7 @@
   - name: Query all the provided contracts to EPG
     when: desiredState == 'present'
     ignore_errors: yes
-    aci_epg_to_contract:
+    cisco.aci.aci_epg_to_contract:
       host: '{{ apicHost }}'
       username: '{{ user }}'
       cert_key: '{{ certKey }}'
@@ -57,10 +59,38 @@
   - debug:
       msg: 'Provider contract name {{ item.fvRsProv.attributes.tnVzBrCPName }}'
     with_items: '{{ query_result.current[0].fvAEPg.children }}'
-    when: query_result.current[0].fvAEPg.children is defined
+    when: (desiredState == 'present') and (query_result.current[0].fvAEPg.children is defined)
+  - name: Query each provided contract to get its annotation
+    ignore_errors: yes
+    cisco.aci.aci_epg_to_contract:
+      host: '{{ apicHost }}'
+      username: '{{ user }}'
+      cert_key: '{{ certKey }}'
+      certificate_name: '{{ certName }}'
+      tenant: '{{ tenant }}'
+      ap: '{{ ap }}'
+      epg: '{{ epgName }}'
+      contract: '{{ item.fvRsProv.attributes.tnVzBrCPName }}'
+      contract_type: provider
+      use_ssl: yes
+      validate_certs: no
+      use_proxy: no
+      state: query
+    with_items: "{{ query_result.current[0].fvAEPg.children }}"
+    when: (desiredState == 'present') and (query_result.current[0].fvAEPg.children is defined)
+    register: contract_query_result
+  - name: Set the provided contract list
+    when: desiredState == 'present'
+    set_fact:
+      providedContractList: '{{ providedContracts }}'
+  - name: Add the provided contracts not owned by us to the list
+    set_fact:
+      providedContractList: "{{ providedContractList + [item.item.fvRsProv.attributes.tnVzBrCPName] }}"
+    with_items: "{{ contract_query_result.results }}"
+    when: (desiredState == 'present') and (contract_query_result.results is defined) and (item.item.fvRsProv.attributes.annotation != annotation)
   - name: Delete the extra provided contracts to EPG
     ignore_errors: yes
-    aci_epg_to_contract:
+    cisco.aci.aci_epg_to_contract:
       host: '{{ apicHost }}'
       cert_key: '{{ certKey }}'
       certificate_name: '{{ certName }}'
@@ -75,11 +105,11 @@
       use_ssl: yes
       validate_certs: no
     with_items: '{{ query_result.current[0].fvAEPg.children }}'
-    when: (desiredState == 'present') and (query_result.current[0].fvAEPg.children is defined) and (item.fvRsProv.attributes.tnVzBrCPName not in providedContracts)
+    when: (desiredState == 'present') and (query_result.current[0].fvAEPg.children is defined) and (item.fvRsProv.attributes.tnVzBrCPName not in providedContractList)
   - name: Add provided contracts to EPG
     when: desiredState == 'present'
     ignore_errors: yes
-    aci_epg_to_contract:
+    cisco.aci.aci_epg_to_contract:
       host: '{{ apicHost }}'
       cert_key: '{{ certKey }}'
       certificate_name: '{{ certName }}'
@@ -89,6 +119,7 @@
       epg: '{{ epgName }}'
       contract: '{{ item }}'
       contract_type: provider
+      annotation: '{{ annotation }}'
       state: present
       use_proxy: no
       use_ssl: yes
@@ -97,7 +128,7 @@
   - name: Query all the consumed contracts to EPG
     when: desiredState == 'present'
     ignore_errors: yes
-    aci_epg_to_contract:
+    cisco.aci.aci_epg_to_contract:
       host: '{{ apicHost }}'
       username: '{{ user }}'
       cert_key: '{{ certKey }}'
@@ -115,10 +146,38 @@
   - debug:
       msg: 'Consumer contract name {{ item.fvRsCons.attributes.tnVzBrCPName }}'
     with_items: '{{ query_result.current[0].fvAEPg.children }}'
-    when: query_result.current[0].fvAEPg.children is defined
+    when: (desiredState == 'present') and (query_result.current[0].fvAEPg.children is defined)
+  - name: Query each consumed contract to get its annotation
+    ignore_errors: yes
+    cisco.aci.aci_epg_to_contract:
+      host: '{{ apicHost }}'
+      username: '{{ user }}'
+      cert_key: '{{ certKey }}'
+      certificate_name: '{{ certName }}'
+      tenant: '{{ tenant }}'
+      ap: '{{ ap }}'
+      epg: '{{ epgName }}'
+      contract: '{{ item.fvRsCons.attributes.tnVzBrCPName }}'
+      contract_type: consumer
+      use_ssl: yes
+      validate_certs: no
+      use_proxy: no
+      state: query
+    with_items: "{{ query_result.current[0].fvAEPg.children }}"
+    when: (desiredState == 'present') and (query_result.current[0].fvAEPg.children is defined)
+    register: contract_query_result
+  - name: Set the consumed contract list
+    when: desiredState == 'present'
+    set_fact:
+      consumedContractList: '{{ consumedContracts }}'
+  - name: Add the consumed contracts not owned by us to the list
+    set_fact:
+      consumedContractList: "{{ consumedContractList + [item.item.fvRsCons.attributes.tnVzBrCPName] }}"
+    with_items: "{{ contract_query_result.results }}"
+    when: (desiredState == 'present') and (contract_query_result.results is defined) and (item.item.fvRsCons.attributes.annotation != annotation)
   - name: Delete the extra consumed contracts to EPG
     ignore_errors: yes
-    aci_epg_to_contract:
+    cisco.aci.aci_epg_to_contract:
       host: '{{ apicHost }}'
       cert_key: '{{ certKey }}'
       certificate_name: '{{ certName }}'
@@ -133,11 +192,11 @@
       use_ssl: yes
       validate_certs: no
     with_items: '{{ query_result.current[0].fvAEPg.children }}'
-    when: (desiredState == 'present') and (query_result.current[0].fvAEPg.children is defined) and (item.fvRsCons.attributes.tnVzBrCPName not in consumedContracts)
+    when: (desiredState == 'present') and (query_result.current[0].fvAEPg.children is defined) and (item.fvRsCons.attributes.tnVzBrCPName not in consumedContractList)
   - name: Add consumed contracts to EPG
     when: desiredState == 'present'
     ignore_errors: yes
-    aci_epg_to_contract:
+    cisco.aci.aci_epg_to_contract:
       host: '{{ apicHost }}'
       cert_key: '{{ certKey }}'
       certificate_name: '{{ certName }}'
@@ -147,6 +206,7 @@
       epg: '{{ epgName }}'
       contract: '{{ item }}'
       contract_type: consumer
+      annotation: '{{ annotation }}'
       state: present
       use_proxy: no
       use_ssl: yes
@@ -155,7 +215,7 @@
   - name: Query Master EPGs
     when: desiredState == 'present'
     ignore_errors: yes
-    aci_rest:
+    cisco.aci.aci_rest:
       host: '{{ apicHost }}'
       username: '{{ user }}'
       cert_key: '{{ certKey }}'
@@ -168,10 +228,36 @@
   - debug:
       msg: '{{ item.fvRsSecInherited.attributes.tDn.split("/")[-1][4:] }}'
     with_items: '{{ query_result.imdata }}'
-    when: query_result.imdata is defined
+    when: (desiredState == 'present') and (query_result.imdata is defined)
+  - name: Query each master EPG to get its annotation
+    ignore_errors: yes
+    cisco.aci.aci_epg_to_contract_master:
+      host: '{{ apicHost }}'
+      username: '{{ user }}'
+      cert_key: '{{ certKey }}'
+      certificate_name: '{{ certName }}'
+      tenant: '{{ tenant }}'
+      ap: '{{ ap }}'
+      epg: '{{ epgName }}'
+      contract_master_ap: '{{ ap }}'
+      contract_master_epg: '{{ item.fvRsSecInherited.attributes.tDn.split("/")[-1][4:] }}'
+      use_ssl: yes
+      validate_certs: no
+      use_proxy: no
+      state: query
+    with_items: "{{ query_result.imdata }}"
+    when: (desiredState == 'present') and (query_result.imdata is defined) and (epgPath in item.fvRsSecInherited.attributes.dn)
+    register: master_query_result
+  - name: Set the master EPG list
+    when: desiredState == 'present'
+    set_fact:
+      masterEpgList: '{{ masterEpgs }}'
+  - name: Add the master EPGs not owned by us to the list
+    set_fact:
+      masterEpgList: "{{ masterEpgList + [item.item.fvRsSecInherited.attributes.tDn.split('/')[-1][4:]] }}"
+    with_items: "{{ master_query_result.results }}"
+    when: (desiredState == 'present') and (master_query_result.results is defined) and (epgPath in item.item.fvRsSecInherited.attributes.dn) and (item.item.fvRsSecInherited.attributes.annotation != annotation)
   - name: Delete extra Master EPGs
-    vars:
-      epgPath: 'uni/tn-{{ tenant }}/ap-{{ ap }}/epg-{{ epgName }}'
     ignore_errors: yes
     cisco.aci.aci_epg_to_contract_master:
       host: '{{ apicHost }}'
@@ -188,7 +274,7 @@
       use_ssl: yes
       validate_certs: no
     with_items: '{{ query_result.imdata }}'
-    when: (desiredState == 'present') and (query_result.imdata is defined) and (epgPath in item.fvRsSecInherited.attributes.dn) and (item.fvRsSecInherited.attributes.tDn.split("/")[-1][4:] not in masterEpgs)
+    when: (desiredState == 'present') and (query_result.imdata is defined) and (epgPath in item.fvRsSecInherited.attributes.dn) and (item.fvRsSecInherited.attributes.tDn.split("/")[-1][4:] not in masterEpgList)
   - name: Attach Master EPGs
     when: (desiredState == 'present')
     cisco.aci.aci_epg_to_contract_master:
@@ -201,6 +287,7 @@
       epg: '{{ epgName }}'
       contract_master_ap: '{{ ap }}'
       contract_master_epg: '{{ item }}'
+      annotation: '{{ annotation }}'
       state: present
       use_proxy: no
       use_ssl: yes
@@ -208,7 +295,7 @@
     loop: '{{ masterEpgs }}'
   - name: Bind EPG to VMM Domain
     when: desiredState == 'present'
-    aci_epg_to_domain:
+    cisco.aci.aci_epg_to_domain:
       host: '{{ apicHost }}'
       cert_key: '{{ certKey }}'
       certificate_name: '{{ certName }}'
@@ -219,6 +306,7 @@
       tenant: '{{ tenant }}'
       ap: '{{ ap }}'
       epg: '{{ epgName }}'
+      annotation: '{{ annotation }}'
       state: present
       use_proxy: no
       use_ssl: yes


### PR DESCRIPTION
1. Add the 'orchestrator:aci-ansible-operator' annotation to
all the resources we create.
2. For Contract CRD, we will only remove the filter entries
created by us.
3. For EPG CRD, we will only remove,
   a. provided/consumed contracts created by us.
   b. contract master EPGs created by us.